### PR TITLE
fix commit 61f1815

### DIFF
--- a/v.alkis.buildings.import.py
+++ b/v.alkis.buildings.import.py
@@ -332,9 +332,7 @@ def import_single_alkis_source(
         )
         returncode = popen_s.wait()
         if returncode != 0:
-            grass.fatal(
-                _("Assigning CRS to ALKIS input data failed!")
-            )
+            grass.fatal(_("Assigning CRS to ALKIS input data failed!"))
             sys.exit()
 
     # snap tolerance = 0.1 to remove overlapping areas in some source datasets

--- a/v.alkis.buildings.import.py
+++ b/v.alkis.buildings.import.py
@@ -381,7 +381,7 @@ def import_single_alkis_source(
             input=alkis_source,
             output=output_alkis,
             extent="region",
-            flags=flags,
+            # flags=flags,
             quiet=True,
         )
     else:
@@ -389,7 +389,7 @@ def import_single_alkis_source(
             "v.import",
             input=alkis_source,
             output=output_alkis,
-            flags=flags,
+            # flags=flags,
             quiet=True,
         )
 

--- a/v.alkis.buildings.import.py
+++ b/v.alkis.buildings.import.py
@@ -313,64 +313,46 @@ def import_single_alkis_source(
     alkis_source, aoi_map, load_region, output_alkis, f_state
 ):
     """Importing single ALKIS source"""
-    iflags = ""
+    alkis_source_fixed = alkis_source
     if f_state == "Hessen":
-        # using -o is dangerous if the GRASS location is in a different CRS
-        # better assign the correct CRS to the input data, e.g. with
-        # ogr2ogr -f VRT -a_srs EPSG:25832 gebaeude_he.vrt ...
-        iflags = "o"
+        # shapefile with missing .prj file, CRS is EPSG:25832
+        alkis_source_fixed = alkis_source[:-4] + "_proj.gpkg"
+        popen_s = grass.Popen(
+            (
+                "ogr2ogr",
+                "-a_srs",
+                "EPSG:25832",
+                "-f",
+                "GPKG",
+                "-nlt",
+                "PROMOTE_TO_MULTI",
+                alkis_source_fixed,
+                alkis_source,
+            )
+        )
+        returncode = popen_s.wait()
+        if returncode != 0:
+            grass.fatal(
+                _("Assigning CRS to ALKIS input data failed!")
+            )
+            sys.exit()
+
+    # snap tolerance = 0.1 to remove overlapping areas in some source datasets
+    snap = -1
+    if f_state == "Thüringen":
+        snap = 0.1
 
     if aoi_map:
         # set region to aoi_map
         grass.run_command("g.region", vector=aoi_map, quiet=True)
-        if f_state == "Thüringen":
-            # parse CRS of current location
-            proj_location = grass.parse_command("g.proj", flags="g")["srid"]
-            proj_location = "EPSG:25832"
-            # change CRS of alkis_source vector data of TH
-            # from epsg:4647 to proj_location
-            # assign CRS to alkis_source vector data of HE
-            alkis_source_proj = alkis_source[:-4] + "_proj.gpkg"
-            popen_s = grass.Popen(
-                (
-                    "ogr2ogr",
-                    "-t_srs",
-                    proj_location,
-                    "-f",
-                    "GPKG",
-                    alkis_source_proj,
-                    alkis_source,
-                )
-            )
-            returncode = popen_s.wait()
-            if returncode != 0:
-                grass.message(
-                    _("Assigning new CRS to ALKIS input data failed!")
-                )
-            # in this case snap tolerance = 0.1 to remove
-            # 8 overlapping areas in source dataset
-            # when changing addon structure add trying out snap
-            # tolerance and not using 0.1 in every case for TH
-            snap = 0.1
-            grass.run_command(
-                "v.in.ogr",
-                input=alkis_source_proj,
-                output=OUTPUT_ALKIS_TEMP,
-                snap=snap,
-                flags=iflags + "r",
-                overwrite=True,
-                verbose=True,
-                quiet=True,
-            )
-        else:
-            grass.run_command(
-                "v.import",
-                input=alkis_source,
-                output=OUTPUT_ALKIS_TEMP,
-                extent="region",
-                flags=iflags,
-                quiet=True,
-            )
+        grass.run_command(
+            "v.import",
+            input=alkis_source_fixed,
+            output=OUTPUT_ALKIS_TEMP,
+            snap=snap,
+            extent="region",
+            quiet=True,
+        )
         grass.run_command(
             "v.clip",
             input=OUTPUT_ALKIS_TEMP,
@@ -382,18 +364,18 @@ def import_single_alkis_source(
     elif load_region:
         grass.run_command(
             "v.import",
-            input=alkis_source,
+            input=alkis_source_fixed,
             output=output_alkis,
+            snap=snap,
             extent="region",
-            flags=iflags,
             quiet=True,
         )
     else:
         grass.run_command(
             "v.import",
-            input=alkis_source,
+            input=alkis_source_fixed,
             output=output_alkis,
-            flags=iflags,
+            snap=snap,
             quiet=True,
         )
 

--- a/v.alkis.buildings.import.py
+++ b/v.alkis.buildings.import.py
@@ -313,9 +313,13 @@ def import_single_alkis_source(
     alkis_source, aoi_map, load_region, output_alkis, f_state
 ):
     """Importing single ALKIS source"""
-    # flags = ""
-    # if f_state == "Hessen":
-    #     flags = "o"
+    iflags = ""
+    if f_state == "Hessen":
+        # using -o is dangerous if the GRASS location is in a different CRS
+        # better assign the correct CRS to the input data, e.g. with
+        # ogr2ogr -f VRT -a_srs EPSG:25832 gebaeude_he.vrt ...
+        iflags = "o"
+
     if aoi_map:
         # set region to aoi_map
         grass.run_command("g.region", vector=aoi_map, quiet=True)
@@ -353,7 +357,7 @@ def import_single_alkis_source(
                 input=alkis_source_proj,
                 output=OUTPUT_ALKIS_TEMP,
                 snap=snap,
-                flags="r",
+                flags=iflags + "r",
                 overwrite=True,
                 verbose=True,
                 quiet=True,
@@ -364,7 +368,7 @@ def import_single_alkis_source(
                 input=alkis_source,
                 output=OUTPUT_ALKIS_TEMP,
                 extent="region",
-                # flags=flags,
+                flags=iflags,
                 quiet=True,
             )
         grass.run_command(
@@ -381,7 +385,7 @@ def import_single_alkis_source(
             input=alkis_source,
             output=output_alkis,
             extent="region",
-            # flags=flags,
+            flags=iflags,
             quiet=True,
         )
     else:
@@ -389,7 +393,7 @@ def import_single_alkis_source(
             "v.import",
             input=alkis_source,
             output=output_alkis,
-            # flags=flags,
+            flags=iflags,
             quiet=True,
         )
 


### PR DESCRIPTION
In commit [61f1815](https://github.com/mundialis/v.alkis.buildings.import/commit/61f18152d4a7d83ef7e3d94847b591318eb3408c) for PR #11, the import flags in `import_single_alkis_source()` have been deactivated, but two instances have not been commented out. As a result, `flags` becomes automatically initialized to invalid `d,r` when reaching [L384](https://github.com/mundialis/v.alkis.buildings.import/blob/main/v.alkis.buildings.import.py#L384) and [L392](https://github.com/mundialis/v.alkis.buildings.import/blob/main/v.alkis.buildings.import.py#L392). This PR fixes this.