### PR TITLE
CI: GRASS tests require numpy python package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy
 py7zr
 grass-gis-helpers
 requests


### PR DESCRIPTION
Fixes in CI `tests / grass addon tests` (see [log](https://github.com/mundialis/v.alkis.buildings.import/actions/runs/19545255919/job/55962275489?pr=20))

`ModuleNotFoundError: No module named 'numpy'`

Background: The GRASS `gunittest` suite calls `grass_gis_helpers` which requires numpy.